### PR TITLE
Renamed FlattenEmbeddedStructs and dropped `ts` tag support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Added support for non-struct embedded types (you can now embed fields that are not structs, with full support for struct tags)
 - Built-in `parser.Item` types (`Scalar`, `Map`, `List` etc) are now implemented as pointers (i.e. the methods are implemented via pointer receivers)
 - Renamed `FlattenEmbeddedStructs` to `FlattenEmbeddedTypes`
+- Fully dropped support for legacy `ts` tag
 
 # 2.1.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 - Implemented both hooks (`OnParseItem` and `OnParseField`) for built-in parser
 - Added support for non-struct embedded types (you can now embed fields that are not structs, with full support for struct tags)
 - Built-in `parser.Item` types (`Scalar`, `Map`, `List` etc) are now implemented as pointers (i.e. the methods are implemented via pointer receivers)
+- Renamed `FlattenEmbeddedStructs` to `FlattenEmbeddedTypes`
 
 # 2.1.1
 

--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ type CreateUserFunc func(p Person) error
 func main() {
 	m := mirror.New(config.Config{
 		Enabled:                os.Getenv("ENV") == "dev", // only enable mirror in dev
-		FlattenEmbeddedStructs: false,
+		FlattenEmbeddedTypes: false,
 	})
 
 	m.AddSources(

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ type Person struct {
 	CreatedAt time.Time      `mirror:"name:created_at"`
 	UpdatedAt *time.Time     `mirror:"name:updated_at,type:number"`
 	DeletedAt *time.Time     `mirror:"name:deleted_at"`
-	IsActive  bool           `ts:"name:is_active"` // using deprecated `ts` tag
+	IsActive  bool           `mirror:"name:is_active"`
 }
 
 type CreateUserFunc func(p Person) error

--- a/config/config.go
+++ b/config/config.go
@@ -26,7 +26,7 @@ type Config struct {
 	// Targets are the languages and files to generate types for, at least ONE target MUST be defined
 	Targets []types.TargetInterface
 
-	// FlattenEmbeddedStructs will flatten embedded structs into the parent struct
+	// FlattenEmbeddedTypes will flatten embedded types into the parent struct
 	//
 	// For example:
 	//
@@ -44,15 +44,15 @@ type Config struct {
 	//     BarField string
 	// }
 	//
-	FlattenEmbeddedStructs bool
+	FlattenEmbeddedTypes bool
 }
 
 // DefaultConfig returns a new Config with default values (Mirror is disabled by default)
 func DefaultConfig() *Config {
 	return &Config{
-		Enabled:                false,
-		EnableParserCache:      true,
-		FlattenEmbeddedStructs: true,
+		Enabled:              false,
+		EnableParserCache:    true,
+		FlattenEmbeddedTypes: true,
 	}
 }
 

--- a/examples/main.go
+++ b/examples/main.go
@@ -51,8 +51,8 @@ func main() {
 	start := time.Now()
 
 	m := mirror.New(config.Config{
-		Enabled:                true,
-		FlattenEmbeddedStructs: false,
+		Enabled:              true,
+		FlattenEmbeddedTypes: false,
 	})
 
 	m.Parser().
@@ -119,8 +119,8 @@ func main() {
 		AddSources(*new(Language), Tags{}, Person{}, Collection{}, CreateUserFunc(nil))
 
 	newParser.SetConfig(parser.Config{
-		EnableCaching:          true,
-		FlattenEmbeddedStructs: true,
+		EnableCaching:        true,
+		FlattenEmbeddedTypes: true,
 	})
 
 	err = m.GenerateAndSaveAll()

--- a/examples/main.go
+++ b/examples/main.go
@@ -37,7 +37,7 @@ type Person struct {
 	CreatedAt time.Time      `mirror:"name:created_at"`
 	UpdatedAt *time.Time     `mirror:"name:updated_at,type:number"`
 	DeletedAt *time.Time     `mirror:"name:deleted_at"`
-	IsActive  bool           `                                     ts:"name:is_active"` // using deprecated `ts` tag
+	IsActive  bool           `mirror:"name:is_active"`
 }
 
 type Collection struct {

--- a/extractor/mirror/extract.go
+++ b/extractor/mirror/extract.go
@@ -1,7 +1,6 @@
 package mirrormeta
 
 import (
-	"fmt"
 	"reflect"
 	"strings"
 
@@ -29,17 +28,6 @@ func Extract(field reflect.StructField, root *meta.Meta) (*meta.Meta, error) {
 	}
 
 	mirrorTag := strings.TrimSpace(field.Tag.Get("mirror"))
-
-	// check if there is a `ts` tag in the field (for backwards compatibility)
-	if mirrorTag == "" {
-		// Deprecated: The `ts` struct tag has been deprecated and will be removed in a future release
-		mirrorTag = strings.TrimSpace(field.Tag.Get("ts"))
-		if mirrorTag != "" {
-			fmt.Println(
-				"[WARN:MIRROR] The legacy `ts` struct tag has been deprecated and will be removed in a future release",
-			)
-		}
-	}
 
 	if mirrorTag == "" {
 		return fieldMeta, nil

--- a/extractor/mirror/extract_test.go
+++ b/extractor/mirror/extract_test.go
@@ -45,7 +45,7 @@ func TestJSONTagParser_Parse(t *testing.T) {
 			Source: nameField,
 			Expected: &meta.Meta{
 				OriginalName: "Name",
-				Name:         "first_name",
+				Name:         "Name",
 				Skip:         false,
 				Optional:     false,
 			},

--- a/generator/typescript/generator.go
+++ b/generator/typescript/generator.go
@@ -268,7 +268,7 @@ func (g *Generator) generateStruct(item *parser.Struct, nestingLevel int) (strin
 
 		fieldStr += ": "
 
-		// if the field has an override type (using the `ts` or `mirror` tag), use that
+		// if the field has an override type (using the `mirror` tag), use that
 		if field.Meta.Type != "" {
 			fieldStr += field.Meta.Type
 

--- a/mirror.go
+++ b/mirror.go
@@ -97,7 +97,7 @@ func (m *Mirror) AddTarget(t types.TargetInterface) *Mirror {
 // SetParser() overrides the default parser with a custom parser or any other parser that implements the ParserInterface
 func (m *Mirror) SetParser(p types.ParserInterface) *Mirror {
 	p.SetConfig(parser.Config{
-		FlattenEmbeddedStructs: m.config.FlattenEmbeddedStructs,
+		FlattenEmbeddedTypes: m.config.FlattenEmbeddedTypes,
 		EnableCaching:          m.config.EnableParserCache,
 	})
 

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -345,7 +345,7 @@ func (p *Parser) parseField(fieldName string, field reflect.StructField) (meta.M
 		return meta.Meta{}, err
 	}
 
-	// Parse the custom `mirror` and `ts` struct tags to override the JSON struct tag if present
+	// Parse the custom `mirror` struct tags to override the JSON struct tag if present
 	mirrorMeta, err := extractor.ExtractMirrorMeta(field, jsonMeta)
 	if err != nil {
 		return meta.Meta{}, err

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -22,10 +22,9 @@ type (
 		Item    *Item
 	}
 
-	// TODO: rename FlattenEmbeddedStructs to FlattenEmbeddedTypes
 	Config struct {
-		EnableCaching          bool
-		FlattenEmbeddedStructs bool
+		EnableCaching        bool
+		FlattenEmbeddedTypes bool
 	}
 
 	OnParseItemFunc func(sourceName string, target Item) error
@@ -36,8 +35,8 @@ type (
 		sources []reflect.Type
 		cache   map[string]CacheValue
 
-		enableCaching          bool
-		flattenEmbeddedStructs bool
+		enableCaching        bool
+		flattenEmbeddedTypes bool
 
 		// Hooks
 		onParseItemFn  OnParseItemFunc
@@ -48,10 +47,10 @@ type (
 // New creates a new parser
 func New() *Parser {
 	return &Parser{
-		cache:                  make(map[string]CacheValue),
-		sources:                []reflect.Type{},
-		enableCaching:          true,
-		flattenEmbeddedStructs: false,
+		cache:                make(map[string]CacheValue),
+		sources:              []reflect.Type{},
+		enableCaching:        true,
+		flattenEmbeddedTypes: false,
 	}
 }
 
@@ -64,7 +63,7 @@ func (p *Parser) Reset() {
 // Set the parser's configuration
 func (p *Parser) SetConfig(config Config) error {
 	p.enableCaching = config.EnableCaching
-	p.flattenEmbeddedStructs = config.FlattenEmbeddedStructs
+	p.flattenEmbeddedTypes = config.FlattenEmbeddedTypes
 
 	return nil
 }
@@ -96,8 +95,8 @@ func (p *Parser) SetSources(sources []reflect.Type) {
 }
 
 // Enable or disable flattening of embedded structs
-func (p *Parser) SetFlattenEmbeddedStructs(flatten bool) *Parser {
-	p.flattenEmbeddedStructs = flatten
+func (p *Parser) SetFlattenEmbeddedTypes(flatten bool) *Parser {
+	p.flattenEmbeddedTypes = flatten
 	return p
 }
 
@@ -425,7 +424,7 @@ func (p *Parser) parseStruct(source reflect.Type, nullable bool) (*Struct, error
 		}
 
 		// If it is embedded, parse it as part of the original struct (flatten it)
-		if p.flattenEmbeddedStructs && sourceField.Anonymous &&
+		if p.flattenEmbeddedTypes && sourceField.Anonymous &&
 			sourceField.Type.Kind() == reflect.Struct {
 			item, err := p.Parse(sourceField.Type)
 			if err != nil {

--- a/parser/parser_test.go
+++ b/parser/parser_test.go
@@ -902,7 +902,7 @@ func Test_ParserHooks(t *testing.T) {
 	}
 
 	p := New()
-	p.SetFlattenEmbeddedStructs(true)
+	p.SetFlattenEmbeddedTypes(true)
 
 	p.OnParseItem(func(name string, item Item) error {
 		// Add a new field to the struct if the name is "TargetFoo"
@@ -959,7 +959,7 @@ func runTests(t *testing.T, tests []Test) {
 
 func runTest(t *testing.T, tt Test) {
 	p := New()
-	p.SetFlattenEmbeddedStructs(true) // TODO: make this better
+	p.SetFlattenEmbeddedTypes(true) // TODO: make this better
 
 	got, err := p.Parse(reflect.TypeOf(tt.Source))
 	if err != nil && !tt.WantErr {


### PR DESCRIPTION
- **Renamed FlattenEmbeddedStructs to FlattenEmbeddedTypes**
- **Dropped support for legacy ts tag**
- **Updated CHANGELOG.md**
