### PR TITLE
fix: properly split mirror tag properties

### DIFF
--- a/extractor/mirror/extract.go
+++ b/extractor/mirror/extract.go
@@ -45,7 +45,7 @@ func Extract(field reflect.StructField, root *meta.Meta) (*meta.Meta, error) {
 
 	// split the props into key-value pairs
 	for _, f := range tagFields {
-		kv := strings.Split(f, ":")
+		kv := strings.SplitN(f, ":", 2)
 		if len(kv) != 2 {
 			continue
 		}

--- a/extractor/mirror/extract_test.go
+++ b/extractor/mirror/extract_test.go
@@ -16,6 +16,7 @@ type TestStruct struct {
 	BMI         string   `                     mirror:"-"`
 	NextOfKin   string   `                     mirror:"name:next_of_kin,skip:true"`
 	Connections []string `                     mirror:"name:connected_ids, type:Array<string>, optional:true"`
+	Meta        any      `                     mirror:"name:meta, type:{'foo': string},"`
 }
 
 var testStruct = reflect.TypeOf(TestStruct{})
@@ -30,6 +31,7 @@ func TestJSONTagParser_Parse(t *testing.T) {
 	bmiField, _ := testStruct.FieldByName("BMI")
 	nextOfKinField, _ := testStruct.FieldByName("NextOfKin")
 	connectionsField, _ := testStruct.FieldByName("Connections")
+	metaField, _ := testStruct.FieldByName("Meta")
 
 	if !ok {
 		panic("field not found")
@@ -110,6 +112,17 @@ func TestJSONTagParser_Parse(t *testing.T) {
 				Skip:         false,
 				Optional:     true,
 				Type:         "Array<string>",
+			},
+		},
+		{
+			Name:   "parse object type override",
+			Source: metaField,
+			Expected: &meta.Meta{
+				OriginalName: "Meta",
+				Name:         "meta",
+				Skip:         false,
+				Optional:     false,
+				Type:         "{'foo': string}",
 			},
 		},
 	}


### PR DESCRIPTION
This resolves an issue where type overrides using objects which
contained `:` as in `{foo: bar}` were not being parsed correctly and
silently skipped since they had a length > 2
